### PR TITLE
KAS-4760: Also rename previous versions if they're new

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -297,7 +297,7 @@ function generateName(
       piece.revision > 1
         ? `${
             CONSTANTS.LATIN_ADVERBIAL_NUMERALS[piece.revision - 1]
-          } `.toUpperCase()
+          }`.toUpperCase()
         : "";
 
   const removeVersionSuffix = (title: string) => {
@@ -319,9 +319,10 @@ function generateName(
   
   const title = piece.title.trim();
   const subjectPart = removeVersionSuffix(title);
-  return (
+  const fullGeneratedName = (
     `VR ${plannedStart.getFullYear()} ${dayPart}${monthPart} ${vvPart}` +
     `${agendaitemPurposePart}.${agendaActivityNumberPart}-${piece.position} ` +
     `${subjectPart}${documentTypePart} ${documentVersionPart}`
   );
+  return fullGeneratedName.trim();
 }

--- a/app.ts
+++ b/app.ts
@@ -292,10 +292,36 @@ function generateName(
   if (lastChar && lastChar == lastChar.toLowerCase()) {
     documentTypePart = documentTypePart.toLowerCase() || "";
   }
-  const subjectPart = piece.title.trim();
+
+  const documentVersionPart =
+      piece.revision > 1
+        ? `${
+            CONSTANTS.LATIN_ADVERBIAL_NUMERALS[piece.revision - 1]
+          } `.toUpperCase()
+        : "";
+
+  const removeVersionSuffix = (title: string) => {
+    const versionSuffixes = `${
+        `(${Object.values(CONSTANTS.LATIN_ADVERBIAL_NUMERALS)
+          .map((suffix) => suffix.toUpperCase())
+          .join(')|(')})`
+        .replace('()|', '')
+        }`;
+
+    const regex = new RegExp(`(.*?)${versionSuffixes}?$`);
+
+    return regex.test(title)
+    ? title
+      .replace(new RegExp(`${versionSuffixes}$`, 'ui'), '')
+      .trim()
+    : title;
+  };
+  
+  const title = piece.title.trim();
+  const subjectPart = removeVersionSuffix(title);
   return (
     `VR ${plannedStart.getFullYear()} ${dayPart}${monthPart} ${vvPart}` +
     `${agendaitemPurposePart}.${agendaActivityNumberPart}-${piece.position} ` +
-    `${subjectPart}${documentTypePart}`
+    `${subjectPart}${documentTypePart} ${documentVersionPart}`
   );
 }

--- a/lib/get-agendaitem-pieces.ts
+++ b/lib/get-agendaitem-pieces.ts
@@ -27,7 +27,6 @@ async function getAgendaitemPieces(agendaitem: string): Promise<Piece[]> {
         WHERE {
           ${sparqlEscapeUri(agendaitem)} 
             besluitvorming:geagendeerdStuk ?piece .
-          FILTER NOT EXISTS { [] pav:previousVersion ?piece }
           ?piece
             dct:title ?pieceName ;
             prov:value / dbpedia:fileExtension ?fileExtension .


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4760

When a new agendaitem has a piece with multiple versions (a case which shouldn't actually occur but that we still wish to cover), we will generate a correct name for all the new versions, not only the last one.

Below screenshot shows a piece that was put on an agendaitem  with 6 versions. All versions got the correct VR number and suffix and the stamps are also right.
![image](https://github.com/user-attachments/assets/0df1836f-1832-41c0-ab23-411d9ff9730a)
