### PR TITLE
KAS-4713 include agendaitem in piece name mapping to be able to regenerate decisions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -24,6 +24,7 @@ import { getRatification } from './lib/get-ratification';
 type FileMapping = {
   uri: string;
   generatedName: string;
+  agendaitem: Agendaitem;
 };
 
 app.use(bodyParser.json());
@@ -220,7 +221,7 @@ async function getNamedPieces(req: Request, res: Response) {
 
       for (const piece of piecesResults) {
         const generatedName = generateName(agenda, agendaitem, piece);
-        mappings.push({ uri: piece.uri, generatedName });
+        mappings.push({ uri: piece.uri, generatedName, agendaitem });
       }
     }
 
@@ -331,7 +332,7 @@ function generateName(
       .trim()
     : title;
   };
-  
+
   const title = piece.title.trim();
   const subjectPart = removeVersionSuffix(title);
   const fullGeneratedName = (

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -24,7 +24,7 @@ async function getSortedAgendaitems(agendaId: string): Promise<Agendaitem[]> {
     ${prefixHeaderLines.schema}
     ${prefixHeaderLines.prov}
 
-    SELECT DISTINCT ?agendaitem ?subcaseType
+    SELECT DISTINCT ?agendaitem ?agendaitemId ?subcaseType
       ?agendaitemType ?isPostponed ?agendaActivityNumber ?position WHERE {
       GRAPH ${sparqlEscapeUri(CONSTANTS.GRAPHS.KANSELARIJ)} {
           VALUES ?agendaId { ${sparqlEscapeString(agendaId)} }
@@ -36,6 +36,7 @@ async function getSortedAgendaitems(agendaId: string): Promise<Agendaitem[]> {
             / prov:wasInformedBy
             / ext:indieningVindtPlaatsTijdens ?subcase ;
             ext:formeelOK ${sparqlEscapeUri(CONSTANTS.FORMALLY_OK_STATUSSES.FORMALLY_OK)} ;
+            mu:uuid ?agendaitemId ;
             schema:position ?position .
           OPTIONAL { ?subcase dct:type ?subcaseType }
           OPTIONAL { ?subcase adms:identifier ?agendaActivityNumber }
@@ -69,6 +70,7 @@ async function getSortedAgendaitems(agendaId: string): Promise<Agendaitem[]> {
     propShapers: {
       subcaseType: { kind: "literal" },
       type: { kind: "literal", sourceProp: "agendaitemType" },
+      id: { kind: "literal", sourceProp: "agendaitemId" },
       isPostponed: { kind: "literal" },
       agendaActivityNumber: { kind: "literal" },
     },
@@ -265,11 +267,11 @@ async function updatePieceName(
         ${escapedPiece} dct:title ?title .
         OPTIONAL {
           ${escapedPiece} prov:value ?file .
-          ?file 
+          ?file
             nfo:fileName ?fileName ;
             dbpedia:fileExtension ?extension .
           OPTIONAL {
-            ?derived 
+            ?derived
               prov:hadPrimarySource ?file ;
               nfo:fileName ?derivedFileName ;
               dbpedia:fileExtension ?derivedFileExtension .

--- a/types/types.ts
+++ b/types/types.ts
@@ -11,6 +11,7 @@ type Meeting = {
 };
 
 type Agendaitem = {
+  id: string;
   uri: string;
   subcaseType: string;
   type: string;


### PR DESCRIPTION
Agendaitem ids are needed for https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2218

We already have them here, so it was easy to include them at no extra querying cost