### PR TITLE
KAS-4883 refactor job status, job model predicates, fix inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,7 @@ Add the following snippet to your `docker-compose.yml` file to include the docum
 
 ```yml
 document-naming-service:
-  image: kanselarij/document-naming-service:0.3.8
-```
-
-The service supports the following environment variables:
-
-```yml
-    environment:
-      ENABLE_SENDING_TO_VP_API: false
+  image: kanselarij/document-naming-service
 ```
 
 Add the following snippet to your `dispatcher.ex` config file to expose this service's endpoint.
@@ -22,4 +15,26 @@ Add the following snippet to your `dispatcher.ex` config file to expose this ser
 match "/document-naming/*path", @json_service do
   Proxy.forward conn, path, "http://document-naming/"
 end
+```
+
+#### Resources
+
+`domain.lisp`:
+```lisp
+(define-resource document-naming-job ()
+  :class (s-prefix "ext:DocumentNamingJob") ; "cogs:Job"
+  :properties `((:created       :datetime  ,(s-prefix "dct:created"))
+                (:status        :uri       ,(s-prefix "adms:status"))
+                (:time-started  :datetime  ,(s-prefix "prov:startedAtTime"))
+                (:time-ended    :datetime  ,(s-prefix "prov:endedAtTime"))
+                (:message       :string    ,(s-prefix "schema:error"))
+  )
+  :has-one `((agenda            :via       ,(s-prefix "dct:source")
+                                :as "source"))
+  :has-many `((piece            :via       ,(s-prefix "prov:used")
+                                :as "used"))
+  :resource-base (s-url "http://example.com/id/document-naming-jobs/")
+  :features '(include-uri)
+  :on-path "document-naming-jobs"
+)
 ```

--- a/app.ts
+++ b/app.ts
@@ -82,7 +82,7 @@ app.post("/agenda/:agenda_id", async function (req: Request, res: Response) {
   const authorized = await jobExists(job.uri);
   if (!authorized) {
     return res.status(403).send(JSON.stringify({
-      error: "You don't have the required access rights to change change document names",
+      error: "You don't have the required access rights to change document names",
     }));
   }
 
@@ -127,11 +127,11 @@ app.post("/agenda/:agenda_id", async function (req: Request, res: Response) {
         agendaitem.agendaActivityNumber
       );
     }
-    const { SUCCESS } = CONSTANTS.JOB.STATUS;
+    const { SUCCESS } = CONSTANTS.JOB.STATUSES;
     await updateJobStatus(job.uri, SUCCESS);
   } catch (e) {
-    const { FAIL } = CONSTANTS.JOB.STATUS;
-    await updateJobStatus(job.uri, FAIL, getErrorMessage(e));
+    const { FAILED } = CONSTANTS.JOB.STATUSES;
+    await updateJobStatus(job.uri, FAILED, getErrorMessage(e));
   }
   return;
 });

--- a/app.ts
+++ b/app.ts
@@ -186,8 +186,8 @@ app.post("/agenda/:agenda_id", async function (req: Request, res: Response) {
 
     if (failedAgendaitems.length) {
       console.log(`agendaitems where document numbering failed: ${failedAgendaitems?.map(agendaitem => agendaitem.uri).join('\n')}`);
-      const { FAIL } = CONSTANTS.JOB.STATUS;
-      await updateJobStatus(job.uri, FAIL, 'De documenten van 1 of meerdere agendapunten konden niet worden genummerd');
+      const { FAILED } = CONSTANTS.JOB.STATUSES;
+      await updateJobStatus(job.uri, FAILED, 'De documenten van 1 of meerdere agendapunten konden niet worden genummerd');
       return;
     }
     const { SUCCESS } = CONSTANTS.JOB.STATUSES;
@@ -272,12 +272,12 @@ app.post("/meeting/:meeting_id/change-dates", async function (req: Request, res:
     // start the process
     await replacePieceVRNameDate(allPieces, date_to);
 
-    const { SUCCESS } = CONSTANTS.JOB.STATUS;
+    const { SUCCESS } = CONSTANTS.JOB.STATUSES;
     await updateJobStatus(job.uri, SUCCESS);
   } catch (e) {
-    const { FAIL } = CONSTANTS.JOB.STATUS;
+    const { FAILED } = CONSTANTS.JOB.STATUSES;
     if (job?.uri) {
-      await updateJobStatus(job.uri, FAIL, getErrorMessage(e));
+      await updateJobStatus(job.uri, FAILED, getErrorMessage(e));
     } else {
       return res.status(500).send(
       JSON.stringify({

--- a/constants.ts
+++ b/constants.ts
@@ -29,13 +29,13 @@ export default {
     INGETROKKEN:
       "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/453a36e8-6fbd-45d3-b800-ec96e59f273b",
   },
-  AGENDA_STATUSSES: {
+  AGENDA_STATUSES: {
     APPROVED:
       "http://themis.vlaanderen.be/id/concept/agenda-status/fff6627e-4c96-4be1-b483-8fefcc6523ca",
     DESIGN:
       "http://themis.vlaanderen.be/id/concept/agenda-status/b3d8a99b-0a7e-419e-8474-4b508fa7ab91",
   },
-  FORMALLY_OK_STATUSSES: {
+  FORMALLY_OK_STATUSES: {
     FORMALLY_OK: "http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636",
   },
   LATIN_ADVERBIAL_NUMERALS: [
@@ -56,10 +56,11 @@ export default {
     "qiundecies",
   ],
   JOB: {
-    STATUS: {
-      RUNNING: "http://vocab.deri.ie/cogs#Running",
-      SUCCESS: "http://vocab.deri.ie/cogs#Success",
-      FAIL: "http://vocab.deri.ie/cogs#Fail",
+    STATUSES: {
+      SCHEDULED: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+      BUSY: "http://redpencil.data.gift/id/concept/JobStatus/busy",
+      SUCCESS: "http://redpencil.data.gift/id/concept/JobStatus/success",
+      FAILED: "http://redpencil.data.gift/id/concept/JobStatus/failed",
     },
     RDF_TYPE: "http://mu.semte.ch/vocabularies/ext/DocumentNamingJob",
     RDF_RESOURCE_BASE: "http://mu.semte.ch/services/document-naming",

--- a/lib/add-agenda-subcase-id.ts
+++ b/lib/add-agenda-subcase-id.ts
@@ -1,12 +1,15 @@
 import { sparqlEscapeUri, sparqlEscapeInt } from "mu";
 import { updateSudo } from "@lblod/mu-auth-sudo";
 import CONSTANTS from "../constants";
+import { prefixHeaderLines } from "./sparql-utils";
 
 async function addAgendaSubcaseId(
   subcase: string,
   agendaActivityNumber: number
 ): Promise<void> {
-  const queryString = `PREFIX adms: <http://www.w3.org/ns/adms#>
+  const queryString = `
+  ${prefixHeaderLines.adms}
+
 INSERT DATA {
   GRAPH ${sparqlEscapeUri(CONSTANTS.GRAPHS.KANSELARIJ)} {
     ${sparqlEscapeUri(subcase)} adms:identifier ${sparqlEscapeInt(

--- a/lib/add-piece-original-name.ts
+++ b/lib/add-piece-original-name.ts
@@ -1,12 +1,15 @@
 import { sparqlEscapeUri, sparqlEscapeString } from "mu";
 import { updateSudo } from "@lblod/mu-auth-sudo";
 import CONSTANTS from "../constants";
+import { prefixHeaderLines } from "./sparql-utils";
 
 async function addPieceOriginalName(
   piece: string,
   originalName: string
 ): Promise<void> {
-  const queryString = `PREFIX dct: <http://purl.org/dc/terms/>
+  const queryString = `
+  ${prefixHeaderLines.dct}
+
 INSERT DATA {
   GRAPH ${sparqlEscapeUri(CONSTANTS.GRAPHS.KANSELARIJ)} {
     ${sparqlEscapeUri(piece)} dct:alternative ${sparqlEscapeString(

--- a/lib/add-piece-position.ts
+++ b/lib/add-piece-position.ts
@@ -1,12 +1,15 @@
 import { sparqlEscapeUri, sparqlEscapeInt } from "mu";
 import { updateSudo } from "@lblod/mu-auth-sudo";
 import CONSTANTS from "../constants";
+import { prefixHeaderLines } from "./sparql-utils";
 
 async function addPiecePosition(
   piece: string,
   position: number
 ): Promise<void> {
-  const queryString = `PREFIX schema: <http://schema.org/>
+  const queryString = `
+  ${prefixHeaderLines.schema}
+
 INSERT DATA {
   GRAPH ${sparqlEscapeUri(CONSTANTS.GRAPHS.KANSELARIJ)} {
     ${sparqlEscapeUri(piece)} schema:position ${sparqlEscapeInt(position)} .

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -35,7 +35,7 @@ async function getSortedAgendaitems(agendaId: string): Promise<Agendaitem[]> {
             ^besluitvorming:genereertAgendapunt
             / prov:wasInformedBy
             / ext:indieningVindtPlaatsTijdens ?subcase ;
-            ext:formeelOK ${sparqlEscapeUri(CONSTANTS.FORMALLY_OK_STATUSSES.FORMALLY_OK)} ;
+            ext:formeelOK ${sparqlEscapeUri(CONSTANTS.FORMALLY_OK_STATUSES.FORMALLY_OK)} ;
             mu:uuid ?agendaitemId ;
             schema:position ?position .
           OPTIONAL { ?subcase dct:type ?subcaseType }
@@ -168,7 +168,7 @@ async function getLastAgendaActivityNumber(
           ?agendaStatusActivity
             prov:used ?agenda ;
             generiek:bewerking ${sparqlEscapeUri(
-              CONSTANTS.AGENDA_STATUSSES.APPROVED
+              CONSTANTS.AGENDA_STATUSES.APPROVED
             )} ;
             prov:startedAtTime ?agendaApprovedDateTime .
           ?agenda

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "TODO"
+    "url": "git+https://github.com/kanselarij-vlaanderen/document-naming-service.git"
   },
   "author": "redpencil.io",
   "license": "MIT",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4883

ext:status > adms:status
prov:used for agenda > dct:source  (just to remove the duplicate use of prov:used for 2 different resources)
use redpencil statuses instead of cogs (cogs doesn't have "scheduled" status which is needed for some jobs)

side tracking:
Correct plural of status is statuses, not statu**ss**es
readme was showing VP stuff
prefix usage were not consistent


also consider the cleanup branch (or risk forgetting about it)
- [ ] https://github.com/kanselarij-vlaanderen/document-naming-service/pull/9
