### PR TITLE
KAS-5213 add blacklisted numbers via env properties

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -31,6 +31,7 @@ import {
   sparqlEscapeInt,
 } from "mu";
 import { replacePieceVRNameDate } from './lib/change-date';
+import { COUNTER_BLACKLIST } from './config';
 
 type FileMapping = {
   uri: string;
@@ -416,7 +417,17 @@ function increaseCounters(
   const { type: agendaitemType, subcaseType } = agendaitem;
   const agendaitemPurpose = getAgendaitemPurpose(agendaitemType, subcaseType);
   const isPvv = agenda.meeting.type === CONSTANTS.MEETING_TYPES.PVV;
-  counters[isPvv ? "pvv" : "regular"][agendaitemPurpose]++;
+  const type = isPvv ? "pvv" : "regular";
+  counters[type][agendaitemPurpose]++;
+
+  // get blacklisted numbers (subcases that are postponed to a new year reuse their number IF there has been a NEW document)
+  const blacklisted = COUNTER_BLACKLIST[type][agendaitemPurpose];
+  
+  // skipping blacklisted numbers
+  while (blacklisted.includes(counters[type][agendaitemPurpose])) {
+    console.log(`**skipping blacklisted number ${counters[type][agendaitemPurpose]} for meeting type ${type} and document ${agendaitemPurpose} **`);
+    counters[type][agendaitemPurpose]++;
+  }
 }
 
 function generateName(

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,24 @@
+const COUNTER_BLACKLIST = {
+  regular: {
+    doc: parseToNumberList(process.env.BLACKLIST_REGULAR_DOC),
+    med: parseToNumberList(process.env.BLACKLIST_REGULAR_MED),
+    dec: parseToNumberList(process.env.BLACKLIST_REGULAR_DEC),
+  },
+  pvv: {
+    doc: parseToNumberList(process.env.BLACKLIST_PVV_DOC),
+    med: parseToNumberList(process.env.BLACKLIST_PVV_MED),
+    dec: parseToNumberList(process.env.BLACKLIST_PVV_DEC),
+  }
+}
+
+function parseToNumberList(value: any) {
+  if (!value) {
+    return [0];
+  }
+  const strings = value.split(',');
+  return strings.map((str: string) => parseInt(str));
+}
+
+export {
+  COUNTER_BLACKLIST
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
 
     // Others (5)
     "noUncheckedIndexedAccess": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noFallthroughCasesInSwitch": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Do not merge: Replaced by https://github.com/kanselarij-vlaanderen/document-naming-service/pull/15/

https://kanselarij.atlassian.net/browse/KAS-5213

This is a first way to handle the issue.
More manual work to maintain, but easiest to implement and doesn't require heavy queries to calculate the blacklists.
Some of the code will be needed if we go forward with a solution where we calculate the blacklisted numbers from the data.

note: Any other solution where we would use queries to work with a blacklist will mean a lot more queries each time we run the mapping. And currently only for 1 number that is blacklisted. So unless we find some nice approach or add some custom data to make finding this blacklisted number easier this might not be worth increasing the load on the database.

- Added ENV properties to add to the container (There are 6 counters). the format is a comma separated list of numbers in string format "1,2,3"
- Use the blacklists to increase the counters for the mapping and the actual numbering.
- the config was complaining about `process.env.property` having to be `process.env['property']` but that seems to be an issue with the rule `noPropertyAccessFromIndexSignature`, so I removed it


todo update readme?